### PR TITLE
V2023.3.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - python
-    - calver
+    - calver 2022.6.26
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - calver
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,15 @@ test:
 about:
   home: https://github.com/pypa/trove-classifiers
   summary: Canonical source for classifiers on PyPI (pypi.org).
+  description: | 
+    Canonical source for classifiers on PyPI. 
+    Classifiers categorize projects per PEP 301. 
+    Use this package to validate classifiers in packages for PyPI upload or download.
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
+  dev_url: https://github.com/pypa/trove-classifiers
+  doc_url: https://pypi.org/project/trove-classifiers/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[Upstream](https://github.com/pypa/trove-classifiers)
[Changelog](https://pypi.org/project/trove-classifiers/#history)

### Actions
- Update dependencies
- Linter fixes