### PR TITLE
Update to 2023.10.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trove-classifiers" %}
-{% set version = "2023.3.9" %}
+{% set version = "2023.10.18" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trove-classifiers-{{ version }}.tar.gz
-  sha256: ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03
+  sha256: 2cdfcc7f31f7ffdd57666a9957296089ac72daad4d11ab5005060e5cd7e29939
 
 build:
   skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -35,9 +35,9 @@ test:
 about:
   home: https://github.com/pypa/trove-classifiers
   summary: Canonical source for classifiers on PyPI (pypi.org).
-  description: | 
-    Canonical source for classifiers on PyPI. 
-    Classifiers categorize projects per PEP 301. 
+  description: |
+    Canonical source for classifiers on PyPI.
+    Classifiers categorize projects per PEP 301.
     Use this package to validate classifiers in packages for PyPI upload or download.
   license: Apache-2.0
   license_family: Apache


### PR DESCRIPTION
Simply updating to Update to 2023.10.18.

Upstream: https://github.com/pypa/trove-classifiers/tree/2023.10.18

Note that trove-classifiers should be kept up to date as much as possible since packages like "hatching" rely on it to validate classifiers in pyproject.toml files.