### PR TITLE
Trove-classifiers update v2024.10.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "trove-classifiers" %}
-{% set version = "2023.10.18" %}
+{% set version = "2024.10.14" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trove-classifiers-{{ version }}.tar.gz
-  sha256: 2cdfcc7f31f7ffdd57666a9957296089ac72daad4d11ab5005060e5cd7e29939
+  url: https://github.com/pypa/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: e57a5cfa85a5995234b887069fc040fe7f7a628b8f4322f51d60b640162d5ea9
 
 build:
   skip: true  # [py<38]


### PR DESCRIPTION
trove-classifiers 2024.10.14

**Destination channel:** defaults

### Links
- [Ticket](https://anaconda.atlassian.net/browse/PKG-5967)
- [trove-classifiers](https://github.com/pypa/trove-classifiers)

### Explanation of changes:
- Update from 2023 to 2024.10.14 for new Frameworks