### PR TITLE
2026.1.14.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,15 +27,15 @@ requirements:
     - python
 
 {% set tests_to_skip = "" %}
-hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
-                         # no special security
-                         None, None,
-                         int(not close_fds),
-                         creationflags,
-                         env,
-                         cwd,
-                         startupinfo)
-                         FileNotFoundError: [WinError 2] The system cannot find the file specified
+# hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
+#                          # no special security
+#                          None, None,
+#                          int(not close_fds),
+#                          creationflags,
+#                          env,
+#                          cwd,
+#                          startupinfo)
+#                          FileNotFoundError: [WinError 2] The system cannot find the file specified
 {% set tests_to_skip = tests_to_skip + '-k "not (test_entry_point or test_module_run_is_entry_point)"' %}  # [win]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trove-classifiers" %}
-{% set version = "2025.5.9.12" %}
+{% set version = "2026.1.14.14" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pypa/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: e2073313aeed13ca9c305ad6cacc2bed0c42a1170ef843f67e1e27c3d98c39c1
+  sha256: aad9b7b24472eda66c29566d546804ac5eaf625ceed359a16fd25e3351766102
 
 build:
   skip: true  # [py<38]
@@ -36,7 +36,7 @@ requirements:
 #                          cwd,
 #                          startupinfo)
 #                          FileNotFoundError: [WinError 2] The system cannot find the file specified
-{% set tests_to_skip = tests_to_skip + '-k "not (test_entry_point or test_module_run_is_entry_point)"' %}  # [win]
+# {% set tests_to_skip = tests_to_skip + '-k "not (test_entry_point or test_module_run_is_entry_point)"' %}  # [win]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - python
-    - calver
+    - calver 2025
     - pip
     - setuptools
     - wheel
@@ -27,16 +27,16 @@ requirements:
     - python
 
 {% set tests_to_skip = "" %}
-# hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
-#                          # no special security
-#                          None, None,
-#                          int(not close_fds),
-#                          creationflags,
-#                          env,
-#                          cwd,
-#                          startupinfo)
-#                          FileNotFoundError: [WinError 2] The system cannot find the file specified
-# {% set tests_to_skip = tests_to_skip + '-k "not (test_entry_point or test_module_run_is_entry_point)"' %}  # [win]
+hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
+                         # no special security
+                         None, None,
+                         int(not close_fds),
+                         creationflags,
+                         env,
+                         cwd,
+                         startupinfo)
+                         FileNotFoundError: [WinError 2] The system cannot find the file specified
+{% set tests_to_skip = tests_to_skip + '-k "not (test_entry_point or test_module_run_is_entry_point)"' %}  # [win]
 
 test:
   source_files:


### PR DESCRIPTION
trove-classifier 2026.1.14.14

**Destination channel:**  defaults

### Links

- [/PKG-12046](https://anaconda.atlassian.net/browse/PKG-12046) 
- [Upstream repository](https://github.com/pypa/trove-classifiers/tree/2026.1.14.14)

### Changes
- Bump version and SHA
- Add host pinning to appease linter. 
- Verified windows test skips are still needed. 
